### PR TITLE
Fix mhz14a driver

### DIFF
--- a/usb_co2.ino
+++ b/usb_co2.ino
@@ -2,7 +2,9 @@
 #define LED_OFF HIGH
 #define PIN_SW1 3
 #define PIN_SW2 2
-#define STATUS_OK 0
+#define INTERVAL_UPDATE 1000
+#define INTERVAL_LOOP 1
+#define SERIAL_TX_MARGIN 13
 
 void setup() {
   digitalWrite(LED_BUILTIN, LED_OFF);
@@ -28,14 +30,27 @@ void setup() {
 
 void loop() {
   int value = 0;
+  int status = 0;
+  static int interval_cnt = INTERVAL_UPDATE;
 
-  value = usb_mhz14a_get_co2();
+  if( 0 >= interval_cnt ){
+    usb_mhz14a_co2_request();
+  }
+  else if( 0 == usb_mhz14a_co2_is_ready() ){
+    status = usb_mhz14a_get_co2( &value );
+    Serial.print("co2=");
+    if( 0 == status ){
+      Serial.print(value, DEC);
+    }
+    Serial.print(";status=");
+    Serial.print(status);
+    Serial.print("\n");
+  }
 
-  Serial.print("co2=");
-  Serial.print(value, DEC);
-  Serial.print(";status=");
-  Serial.print(STATUS_OK);
-  Serial.print("\n");
+  if( 0 >= interval_cnt ){
+    interval_cnt = INTERVAL_UPDATE - SERIAL_TX_MARGIN;
+  }
+  interval_cnt -= INTERVAL_LOOP;
 
-  delay(1000);
+  delay( INTERVAL_LOOP );
 }

--- a/usb_mhz14a.ino
+++ b/usb_mhz14a.ino
@@ -67,7 +67,7 @@ int usb_mhz14a_get_co2(){
   delay(10);
 
   int c = 0;
-  int message[9];
+  int message[9] = {0};
 
   while (mySerial.available()) {
     int b = mySerial.read();

--- a/usb_mhz14a.ino
+++ b/usb_mhz14a.ino
@@ -61,13 +61,14 @@ void usb_mhz14a_init(){
   delay(10);
 }
 
-int usb_mhz14a_get_co2(){
+int usb_mhz14a_get_co2( int *value ){
   mySerial.write(command_get_co2, sizeof(command_get_co2));
 
   delay(10);
 
   int c = 0;
   int message[9] = {0};
+  int ret = 0;
 
   while (mySerial.available()) {
     int b = mySerial.read();
@@ -79,9 +80,9 @@ int usb_mhz14a_get_co2(){
 
   int high_byte = message[2];
   int low_byte = message[3];
-  int value = high_byte * 256 + low_byte;
+  *value = high_byte * 256 + low_byte;
 
-  return value;
+  return ret;
 }
 
 void usb_mhz14a_abc_off(){
@@ -100,7 +101,6 @@ void usb_mhz14a_zero_calibration(){
   int cnt = 0;
 
   for( cnt = 0; cnt < ( CALIB_TIME * 60 ); cnt++){
-    usb_mhz14a_get_co2();
     delay(1000);
   }
 

--- a/usb_mhz14a.ino
+++ b/usb_mhz14a.ino
@@ -1,6 +1,8 @@
 #include <SoftwareSerial.h>
 
 #define CALIB_TIME 30 // per min
+#define RESULT_OK 0
+#define RESULT_NG 1
 
 //SoftwareSerial mySerial(14, 15); // RX, TX for WNPink
 //SoftwareSerial mySerial(16, 10); // RX, TX for ProMicro
@@ -61,11 +63,19 @@ void usb_mhz14a_init(){
   delay(10);
 }
 
-int usb_mhz14a_get_co2( int *value ){
+void usb_mhz14a_co2_request(){
   mySerial.write(command_get_co2, sizeof(command_get_co2));
+}
 
-  delay(10);
+int usb_mhz14a_co2_is_ready(){
+  if( 8 < mySerial.available() ){
+    return RESULT_OK;
+  }
 
+  return RESULT_NG;
+}
+
+int usb_mhz14a_get_co2( int *value ){
   int c = 0;
   int message[9] = {0};
   int ret = 0;
@@ -82,7 +92,11 @@ int usb_mhz14a_get_co2( int *value ){
   int low_byte = message[3];
   *value = high_byte * 256 + low_byte;
 
-  return ret;
+  if( 0 > *value ){
+    return RESULT_NG;
+  }
+
+  return RESULT_OK;
 }
 
 void usb_mhz14a_abc_off(){


### PR DESCRIPTION
#27 に対する修正と、もう少し正確に5秒周期で読み出せるようにした

・ソフトウェアシリアルの受信バッファの初期化忘れを修正
・MH-Zxxドライバの作りをブロッキングからノンブロッキングにした